### PR TITLE
Fix Jekyll formatting

### DIFF
--- a/_posts/2017-01-28-javascript-for-scala-developers.md
+++ b/_posts/2017-01-28-javascript-for-scala-developers.md
@@ -158,6 +158,7 @@ f("a","b", 1 ,2 ,3) //1, 2, 3 will be in the rest array
 ### Modules and imports
 
 In lib.js :
+
 ```javascript
 export function f(x) {
     return x+1;


### PR DESCRIPTION
Jekyll [appears to need][1] a line feed here to parse the triple backtick as a code block.

[1]: http://loicdescotte.github.io/posts/javascript-for-scala-developers/#modules-and-imports